### PR TITLE
Hook basecolor to blender's diffuse color, calculate shininess from roughness

### DIFF
--- a/src/SceneWriter.py
+++ b/src/SceneWriter.py
@@ -213,10 +213,10 @@ class SceneWriter:
                 1.0)
         else:
             virtual_material.base_color = (
-                material.pbepbs.basecolor[0],
-                material.pbepbs.basecolor[1],
-                material.pbepbs.basecolor[2],
-                material.pbepbs.transparency)
+                material.diffuse_color[0],
+                material.diffuse_color[1],
+                material.diffuse_color[2],
+                material.alpha)
             virtual_material.metallic = 1.0 if material.pbepbs.metallic else 0.0
             virtual_material.roughness = material.pbepbs.roughness
             virtual_material.refractive_index = material.pbepbs.ior


### PR DESCRIPTION
This change hooks base color to blender's diffuse color and transparency to blender's alpha for better compatibility, and also to get at least some indication of what material it is in the blender viewport.

It also calculates specular_hardness based on the roughness using the same formula Panda uses.
